### PR TITLE
hhvm-nightly not supported any more TravisCI travis-ci/travis-ci#3788

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,12 @@ php:
   - 5.5
   - 5.4
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: 7.0
     - php: hhvm
-    - php: hhvm-nightly
         
 branches:
   only:


### PR DESCRIPTION
:construction_worker_man: HHVM nightly is no longer supported on TravisCI - travis-ci/travis-ci#3788